### PR TITLE
feat: 로직 추가 및 disable 안보이게 수정

### DIFF
--- a/src/ruleDispatcher.ts
+++ b/src/ruleDispatcher.ts
@@ -1,5 +1,3 @@
-// src/ruleDispatcher.ts
-
 import * as vscode from "vscode";
 import { RuleContext, RuleFixer } from "./rules/types";
 import {
@@ -8,6 +6,10 @@ import {
   interactiveSupportsFocusFix,
   mouseEventsHaveKeyEventsFix,
   tabindexNoPositiveFix,
+  noNoninteractiveTabindexFix,
+  preferNativeElementsFix,
+  labelHasAssociatedControlFix,
+  anchorIsValidFix,
 } from "./rules/logic";
 
 // 규칙 이름과 수정 로직 함수를 매핑하는 객체
@@ -18,6 +20,10 @@ const ruleFixers: { [key: string]: RuleFixer } = {
   "jsx-a11y/interactive-supports-focus": interactiveSupportsFocusFix,
   "jsx-a11y/mouse-events-have-key-events": mouseEventsHaveKeyEventsFix,
   "jsx-a11y/tabindex-no-positive": tabindexNoPositiveFix,
+  "jsx-a11y/no-noninteractive-tabindex": noNoninteractiveTabindexFix,
+  "jsx-a11y/prefer-native-elements": preferNativeElementsFix,
+  "jsx-a11y/label-has-associated-control": labelHasAssociatedControlFix,
+  "jsx-a11y/anchor-is-valid": anchorIsValidFix,
 };
 
 const a11yDiagnosticCollection =

--- a/src/rules/logic/anchor-is-valid.ts
+++ b/src/rules/logic/anchor-is-valid.ts
@@ -1,0 +1,51 @@
+import * as vscode from "vscode";
+import { RuleContext, RuleFixer } from "../types";
+
+export const anchorIsValidFix: RuleFixer = (
+  context: RuleContext
+): vscode.CodeAction[] => {
+  const { code, range, document } = context;
+  const fixes: vscode.CodeAction[] = [];
+
+  // href 속성이 없거나 비어있는 경우
+  if (!/\shref=["'][^"']*["']/i.test(code) || /\shref=[""]/.test(code)) {
+    const fixed = code.replace(/<a(\s|>)/i, '<a href="#"$1');
+    const fix = new vscode.CodeAction(
+      `href="#" 속성 추가`,
+      vscode.CodeActionKind.QuickFix
+    );
+    fix.edit = new vscode.WorkspaceEdit();
+    fix.edit.replace(document.uri, range, fixed);
+    fix.diagnostics = [
+      {
+        message: `<a> 태그는 유효한 href 속성을 가져야 합니다.`,
+        range,
+        severity: vscode.DiagnosticSeverity.Warning,
+        source: "web-a11y-fixer",
+      },
+    ];
+    fixes.push(fix);
+  }
+
+  // javascript:; 등의 유효하지 않은 값 수정
+  if (/\shref=["']\s*javascript:;["']/i.test(code)) {
+    const fixed = code.replace(/\s*href=["']\s*javascript:;["']/i, ` href="#"`);
+    const fix = new vscode.CodeAction(
+      `href 속성 값을 '#'로 변경`,
+      vscode.CodeActionKind.QuickFix
+    );
+    fix.edit = new vscode.WorkspaceEdit();
+    fix.edit.replace(document.uri, range, fixed);
+    fix.diagnostics = [
+      {
+        message: `<a> 태그는 유효한 href 속성 값을 가져야 합니다.`,
+        range,
+        severity: vscode.DiagnosticSeverity.Warning,
+        source: "web-a11y-fixer",
+      },
+    ];
+    fixes.push(fix);
+  }
+
+  return fixes;
+};

--- a/src/rules/logic/aria-activedescendant-has-tabindex.ts
+++ b/src/rules/logic/aria-activedescendant-has-tabindex.ts
@@ -6,12 +6,18 @@ export function ariaActivedescendantHasTabindexFix(
 ): vscode.CodeAction[] {
   const fixes: vscode.CodeAction[] = [];
 
+  // 이미 tabIndex 속성이 있다면 수정을 제안하지 않음
+  if (context.code.match(/\stabIndex\s*=/i)) {
+    return [];
+  }
+
   const fix = new vscode.CodeAction(
     `aria-activedescendant 요소에 tabIndex="0" 추가`,
     vscode.CodeActionKind.QuickFix
   );
   fix.edit = new vscode.WorkspaceEdit();
 
+  // 열림 태그에 tabIndex="0" 추가
   const newCode = context.code.replace(/^<(\w+)/, `<$1 tabIndex="0"`);
 
   fix.edit.replace(context.document.uri, context.range, newCode);

--- a/src/rules/logic/click-events-have-key-events.ts
+++ b/src/rules/logic/click-events-have-key-events.ts
@@ -7,25 +7,36 @@ export function clickEventsHaveKeyEventsFix(
   const fixes: vscode.CodeAction[] = [];
 
   const fix = new vscode.CodeAction(
-    `클릭 이벤트에 onKeyDown={handleKeyDown} 추가`,
+    `클릭 이벤트에 onKeyDown={...} 키보드 이벤트 추가`,
     vscode.CodeActionKind.QuickFix
   );
   fix.edit = new vscode.WorkspaceEdit();
 
-  const onClickMatch = context.code.match(/(onClick=\{[^}]+\})/);
-  if (!onClickMatch) {
+  // onClick 핸들러의 내용을 추출하는 정규식
+  const onClickMatch = context.code.match(/onClick=\{([^{}]*)\}/);
+  if (!onClickMatch || !onClickMatch[1]) {
     console.warn(
-      `[DEBUG - clickEventsFix] onClick 속성을 찾을 수 없습니다: ${context.code}`
+      `[DEBUG - clickEventsFix] onClick 속성에서 핸들러 내용을 찾을 수 없습니다: ${context.code}`
     );
     return [];
   }
 
-  const onClickAttribute = onClickMatch[0];
+  const onClickBody = onClickMatch[1].trim(); // 함수 본문 추출
+  let newCode = context.code;
 
-  const newCode = context.code.replace(
-    onClickAttribute,
-    `${onClickAttribute} onKeyDown={(event) => { if (event.key === 'Enter' || event.key === ' ') { /* ${onClickAttribute} */ } }}`
-  );
+  if (!newCode.includes("onKeyDown")) {
+    // onKeyDown이 없는 경우
+    newCode = newCode.replace(
+      onClickMatch[0],
+      `${onClickMatch[0]} onKeyDown={(event) => { if (event.key === 'Enter' || event.key === ' ') { ${onClickBody} } }}`
+    );
+  } else {
+    // onKeyDown이 이미 있는 경우 (onClick 코드만 재사용)
+    newCode = newCode.replace(
+      /onKeyDown=\{[^{}]*\}/,
+      `onKeyDown={(event) => { if (event.key === 'Enter' || event.key === ' ') { ${onClickBody} } }}`
+    );
+  }
 
   fix.edit.replace(context.document.uri, context.range, newCode);
   fix.diagnostics = [

--- a/src/rules/logic/index.ts
+++ b/src/rules/logic/index.ts
@@ -3,3 +3,7 @@ export * from "./click-events-have-key-events";
 export * from "./interactive-supports-focus";
 export * from "./mouse-events-have-key-events";
 export * from "./tabindex-no-positive";
+export * from "./no-noninteractive-tabindex";
+export * from "./prefer-native-elements";
+export * from "./label-has-associated-control";
+export * from "./anchor-is-valid";

--- a/src/rules/logic/interactive-supports-focus.ts
+++ b/src/rules/logic/interactive-supports-focus.ts
@@ -6,6 +6,11 @@ export function interactiveSupportsFocusFix(
 ): vscode.CodeAction[] {
   const fixes: vscode.CodeAction[] = [];
 
+  // 이미 tabIndex 속성이 있다면 수정을 제안하지 않음
+  if (context.code.match(/\stabIndex\s*=/i)) {
+    return [];
+  }
+
   const fix = new vscode.CodeAction(
     `인터랙티브 요소에 tabIndex="0" 추가`,
     vscode.CodeActionKind.QuickFix

--- a/src/rules/logic/label-has-associated-control.ts
+++ b/src/rules/logic/label-has-associated-control.ts
@@ -1,0 +1,58 @@
+// src/rules/logic/label-has-associated-control.ts
+import * as vscode from "vscode";
+import { RuleContext, RuleFixer } from "../types";
+
+export const labelHasAssociatedControlFix: RuleFixer = (
+  context: RuleContext
+): vscode.CodeAction[] => {
+  const { code, range, document } = context;
+  const fixes: vscode.CodeAction[] = [];
+
+  // 중첩 케이스: <label>안에 input을 감싸는 형태로 변경
+  const fixNested = new vscode.CodeAction(
+    `label 내부에 input 중첩`,
+    vscode.CodeActionKind.QuickFix
+  );
+  fixNested.edit = new vscode.WorkspaceEdit();
+  fixNested.edit.replace(
+    document.uri,
+    range,
+    `<label>${code}</label>`
+  );
+  fixNested.diagnostics = [
+    {
+      message: `label과 input을 중첩하여 연결하세요.`,
+      range,
+      severity: vscode.DiagnosticSeverity.Warning,
+      source: "web-a11y-fixer",
+    },
+  ];
+  fixes.push(fixNested);
+
+  // for 속성 추가 케이스: id를 추론하여 for 속성 추가
+  const inputIdMatch = context.fullLine.match(/id="([^"]+)"/);
+  if (inputIdMatch) {
+    const inputId = inputIdMatch[1];
+    const fixedCode = code.replace(
+      /<label(.*?)>/i,
+      `<label for="${inputId}"$1>`
+    );
+    const fixFor = new vscode.CodeAction(
+      `for="${inputId}" 속성 추가`,
+      vscode.CodeActionKind.QuickFix
+    );
+    fixFor.edit = new vscode.WorkspaceEdit();
+    fixFor.edit.replace(document.uri, range, fixedCode);
+    fixFor.diagnostics = [
+      {
+        message: `label의 for 속성을 input의 id와 연결하세요.`,
+        range,
+        severity: vscode.DiagnosticSeverity.Warning,
+        source: "web-a11y-fixer",
+      },
+    ];
+    fixes.push(fixFor);
+  }
+
+  return fixes;
+};

--- a/src/rules/logic/no-noninteractive-tabindex.ts
+++ b/src/rules/logic/no-noninteractive-tabindex.ts
@@ -1,0 +1,33 @@
+import * as vscode from "vscode";
+import { RuleContext, RuleFixer } from "../types";
+
+/**
+ * 비인터랙티브 요소에 사용된 tabindex 속성을 제거하는 Fixer
+ */
+export const noNoninteractiveTabindexFix: RuleFixer = (
+  context: RuleContext
+): vscode.CodeAction[] => {
+  const { code, range, document } = context;
+
+  // 'tabIndex' 속성을 제거하는 정규식
+  const fixed = code.replace(/\s*tabIndex\s*=\s*\{?[^}>]*\}?/i, "");
+
+  const fix = new vscode.CodeAction(
+    `tabIndex 속성 제거`,
+    vscode.CodeActionKind.QuickFix
+  );
+
+  fix.edit = new vscode.WorkspaceEdit();
+  fix.edit.replace(document.uri, range, fixed);
+
+  fix.diagnostics = [
+    {
+      message: `tabIndex는 비인터랙티브 요소에 사용될 수 없습니다.`,
+      range,
+      severity: vscode.DiagnosticSeverity.Warning,
+      source: "web-a11y-fixer",
+    },
+  ];
+
+  return [fix];
+};

--- a/src/rules/logic/prefer-native-elements.ts
+++ b/src/rules/logic/prefer-native-elements.ts
@@ -1,0 +1,62 @@
+// src/rules/logic/prefer-native-elements.ts
+import * as vscode from "vscode";
+import { RuleContext, RuleFixer } from "../types";
+
+export const preferNativeElementsFix: RuleFixer = (
+  context: RuleContext
+): vscode.CodeAction[] => {
+  const { code, range, document } = context;
+  const fixes: vscode.CodeAction[] = [];
+
+  // role="link" → <a>로 교체
+  const linkMatch = code.match(/<(?:\w+)\s+role="link"([^>]*)>/i);
+  if (linkMatch) {
+    const attrs = linkMatch[1];
+    const newCode = code.replace(
+      /<(?:\w+)\s+role="link"([^>]*)>/i,
+      `<a href="#"${attrs}>`
+    );
+    const fix = new vscode.CodeAction(
+      `<a> 태그로 교체 (role="link")`,
+      vscode.CodeActionKind.QuickFix
+    );
+    fix.edit = new vscode.WorkspaceEdit();
+    fix.edit.replace(document.uri, range, newCode);
+    fix.diagnostics = [
+      {
+        message: `role="link" 대신 네이티브 <a> 요소를 사용하세요.`,
+        range,
+        severity: vscode.DiagnosticSeverity.Warning,
+        source: "web-a11y-fixer",
+      },
+    ];
+    fixes.push(fix);
+  }
+
+  // role="checkbox" → <input type="checkbox">로 교체
+  const checkboxMatch = code.match(/<(?:\w+)\s+role="checkbox"([^>]*)>/i);
+  if (checkboxMatch) {
+    const attrs = checkboxMatch[1].replace(/\saria-checked/i, "");
+    const newCode = code.replace(
+      /<(?:\w+)\s+role="checkbox"([^>]*)>/i,
+      `<input type="checkbox"${attrs}>`
+    );
+    const fix = new vscode.CodeAction(
+      `<input type="checkbox"> 태그로 교체`,
+      vscode.CodeActionKind.QuickFix
+    );
+    fix.edit = new vscode.WorkspaceEdit();
+    fix.edit.replace(document.uri, range, newCode);
+    fix.diagnostics = [
+      {
+        message: `role="checkbox" 대신 네이티브 <input type="checkbox"> 요소를 사용하세요.`,
+        range,
+        severity: vscode.DiagnosticSeverity.Warning,
+        source: "web-a11y-fixer",
+      },
+    ];
+    fixes.push(fix);
+  }
+
+  return fixes;
+};

--- a/src/test/sampleInput.jsx
+++ b/src/test/sampleInput.jsx
@@ -30,7 +30,29 @@ const BadA11yComponent = () => {
       </div>
 
       {/* ❌ tabindex-no-positive */}
-      <div tabIndex={2}>I have a positive tabIndex</div>
+      <div tabIndex="0">I have a positive tabIndex</div>
+
+      {/* ❌ prefer-native-elements (role="link") */}
+      <div role="link" onClick={() => navigate("/page")}>페이지 이동</div>
+
+      {/* ❌ prefer-native-elements (role="checkbox") */}
+      <span role="checkbox" aria-checked="false">선택</span>
+
+      {/* ❌ label-has-associated-control (for 없음) */}
+      <label>
+        이름
+      </label>
+      <input type="text" id="name" />
+      
+      {/* ❌ anchor-is-valid (href 없음) */}
+      <a onClick={() => scrollToTop()}>
+        Top
+      </a>
+
+      {/* ❌ no-noninteractive-tabindex */}
+      <div tabIndex={0}>
+        나는 비인터랙티브 요소지만 탭 포커스가 가능해
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## 관련 이슈
Resolves: #12

## 작업 사항
새로운 접근성 로직 추가: ESLint jsx-a11y 규칙에 기반한 세 가지 새로운 로직을 구현했습니다.

prefer-native-elements: role="link"와 role="checkbox"를 각각 네이티브 <a href="#"> 및 <input type="checkbox">로 변경하는 기능을 추가했습니다.

label-has-associated-control: <label>과 폼 요소가 연결되도록 for 속성을 추가하거나 중첩 구조로 변경하는 기능을 추가했습니다.

anchor-is-valid: href 속성이 없는 <a> 태그에 유효한 href="#"를 추가하는 기능을 추가했습니다.

no-noninteractive-tabindex: 비인터랙티브 요소에 사용된 tabIndex 속성을 제거하는 기능을 추가했습니다.

빠른 수정(Quick Fix) UI 개선: ESLint가 기본으로 제공하는 'Disable' 옵션을 숨기고, 직접 구현한 수정 옵션과 'Show documentation'만 표시되도록 extension.ts 파일의 로직을 수정했습니다.

- 

## 참고 사항
src/rules/logic 디렉터리에 새로운 로직 파일들을 추가하고, index.ts 및 ruleDispatcher.ts에서 이를 참조하도록 업데이트했습니다.

