### PR TITLE
feat: 빠른 수정 메뉴에서 disable 안보이게 설정

### DIFF
--- a/src/lint/LintManager.ts
+++ b/src/lint/LintManager.ts
@@ -280,7 +280,7 @@ export class LintManager {
           : vscode.DiagnosticSeverity.Information;
       const d = new vscode.Diagnostic(range, m.message, sev);
       (d as any).code = m.ruleId ?? "unknown";
-      d.source = "eslint";
+      d.source = "a11y-fixer";
       out.push(d);
     }
     return out;

--- a/src/test/large-performance-test.tsx
+++ b/src/test/large-performance-test.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+
+/**
+ * AccessibilityFixer 확장 프로그램의 대규모 성능 평가를 위한 테스트 컴포넌트입니다.
+ * 수백 개의 의도적인 접근성 규칙 위반 사례를 포함하여, 확장 프로그램의 린팅 및 수정 제안 속도를 극한 상황에서 테스트합니다.
+ */
+
+// 테스트 케이스를 반복 생성하기 위한 헬퍼 함수
+const repeat = <T,>(item: T, count: number): T[] => Array(count).fill(item);
+
+const LargePerformanceTestComponent = () => {
+  const handleClick = () => console.log('Clicked');
+  const handleMouseOver = () => console.log('MouseOver');
+  const handleMouseOut = () => console.log('MouseOut');
+
+  return (
+    <div>
+      <h1>대규모 성능 테스트</h1>
+      <p>이 파일은 수백 개의 접근성 오류를 포함하고 있습니다. 확장 프로그램이 모든 문제를 진단하는 데 걸리는 시간을 측정하세요.</p>
+
+      {/* ========== 섹션 1: 논리 기반 규칙 위반 (대량 반복) ========== */}
+      <section>
+        <h2>논리 기반 규칙 테스트 (반복)</h2>
+        {repeat(0, 50).map((_, i) => (
+          <div key={`logic-test-${i}`}>
+            {/* 1. tabindex-no-positive */}
+            <span tabIndex={i + 1}>양수 tabIndex</span>
+
+            {/* 2. anchor-is-valid */}
+            <a href="javascript:;">유효하지 않은 링크 #{i}</a>
+            <a>href가 없는 링크 #{i}</a>
+
+            {/* 3. mouse-events-have-key-events */}
+            <div onMouseOver={handleMouseOver} onMouseOut={handleMouseOut}>
+              키보드 이벤트 없는 마우스 이벤트 #{i}
+            </div>
+            
+            {/* 4. no-access-key */}
+            <button accessKey={String.fromCharCode(65 + (i % 26))}>Access Key #{i}</button>
+
+            {/* 5. no-distracting-elements */}
+            <marquee>움직이는 텍스트 #{i}</marquee>
+          </div>
+        ))}
+      </section>
+
+      {/* ========== 섹션 2: AI 기반 규칙 위반 (대량 반복) ========== */}
+      <section>
+        <h2>AI 기반 규칙 테스트 (반복)</h2>
+        {repeat(0, 50).map((_, i) => (
+          <div key={`ai-test-${i}`}>
+            {/* 6. alt-text */}
+            <img src={`image-${i}.jpg`} />
+
+            {/* 7. aria-role */}
+            <div role="buton">잘못된 Role #{i}</div>
+
+            {/* 8. anchor-has-content */}
+            <a href={`/page/${i}`}></a>
+
+            {/* 9. control-has-associated-label */}
+            <input type="text" id={`user-${i}`} />
+            <label>사용자명</label>
+
+            {/* 10. img-redundant-alt */}
+            <img src={`icon-${i}.png`} alt={`icon image ${i}`} />
+            
+            {/* 11. accessible-emoji */}
+            <span>⭐</span><span>👍</span>
+
+            {/* 12. no-interactive-element-to-noninteractive-role */}
+            <button role="presentation">저장 #{i}</button>
+
+            {/* 13. no-noninteractive-element-to-interactive-role */}
+            <div role="button" onClick={handleClick}>클릭 Div #{i}</div>
+          </div>
+        ))}
+      </section>
+
+      {/* ========== 섹션 3: 복합적인 위반 사례 (중첩 및 조합) ========== */}
+      <section>
+        <h2>복합 규칙 위반 테스트</h2>
+        {repeat(0, 30).map((_, i) => (
+          <div key={`complex-test-${i}`} onMouseOver={handleMouseOver}>
+            <h3 role="heading" aria-level={-1}>잘못된 제목 <blink>!</blink></h3>
+            <img src={`complex-${i}.gif`} />
+            <a onClick={handleClick}>
+              <span>아이콘</span>
+            </a>
+            <div role="buton" tabIndex={i + 100} onClick={handleClick} accessKey="x">
+              복합 버튼
+              <span>🔥</span>
+            </div>
+            <input id={`complex-input-${i}`} />
+          </div>
+        ))}
+      </section>
+
+      {/* ========== 섹션 4: 더 많은 단일 위반 사례 ========== */}
+      <section>
+          <h2>추가 단일 위반 사례</h2>
+          {repeat(0, 50).map((_, i) => (
+              <React.Fragment key={`single-more-${i}`}>
+                  {/* heading-has-content */}
+                  <h2></h2>
+                  {/* aria-proptypes */}
+                  <div aria-expanded="maybe">확장 가능?</div>
+                  {/* role-has-required-aria-props */}
+                  <div role="slider"></div>
+                  {/* no-noninteractive-tabindex */}
+                  <p tabIndex={0}>포커스 가능한 문단</p>
+              </React.Fragment>
+          ))}
+      </section>
+    </div>
+  );
+};
+
+export default LargePerformanceTestComponent;

--- a/src/types/jsx.d.ts
+++ b/src/types/jsx.d.ts
@@ -1,6 +1,5 @@
 declare namespace JSX {
-    interface IntrinsicElements {
-      [elem: string]: any; // 테스트용: 모든 태그 허용
-    }
+  interface IntrinsicElements {
+    [elem: string]: any; // 테스트용: 모든 HTML 태그를 허용하도록 설정
   }
-  
+}


### PR DESCRIPTION
## 📌 Key Changes

- 빠른 수정(Quick Fix) 메뉴의 사용자 경험을 개선했습니다.
- `AccessibilityFixer`가 제공하는 수정 액션 외에, ESLint 확장 프로그램이 기본으로 제공하는 'Disable...' 옵션들이 함께 표시되어 혼동을 주는 문제를 해결했습니다.
- 진단(Diagnostic) 정보의 `source`를 고유 식별자로 변경하여, `[A11y Fix]` 관련 액션만 표시되도록 수정했습니다.

---

## 🔗 Related Issues

- Closes # 31

---

## 🔍 Before & After

### Before
빠른 수정 메뉴에 직접 구현하지 않은 'Disable...' 옵션들이 함께 표시됩니다.


### After
`[A11y Fix]`와 같이 직접 구현한 액션만 깔끔하게 표시됩니다.


---

## ✅ Checklist

- [x] `src/lint/LintManager.ts` 파일에서 진단(Diagnostic)의 `source` 속성을 `'a11y-fixer'`로 변경했습니다.
- [x] 빠른 수정 메뉴를 열었을 때 'Disable...' 옵션이 더 이상 나타나지 않는 것을 확인했습니다.